### PR TITLE
Add tests for util

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -14,7 +14,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: paper/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled

--- a/auto_uncertainties/util.py
+++ b/auto_uncertainties/util.py
@@ -15,16 +15,11 @@ T = TypeVar("T", bound=np.generic, covariant=True)
 
 def ignore_runtime_warnings(f):
     """
-    A decorator to ignore runtime warnings
-    Parameters
-    ----------
-    f: function
-        The wrapped function
+    A decorator to ignore runtime warnings.
 
-    Returns
-    -------
-    wrapped_function: function
-        The wrapped function
+    :param f: The functin to wrap
+
+    :return: The wrapped function
     """
 
     @wraps(f)
@@ -39,15 +34,10 @@ def ignore_runtime_warnings(f):
 def ignore_numpy_downcast_warnings(f):
     """
     A decorator to ignore NumpyDowncastWarning
-    Parameters
-    ----------
-    f: function
-        The wrapped function
 
-    Returns
-    -------
-    wrapped_function: function
-        The wrapped function
+    :param f: The function to wrap
+
+    :return: The wrapped function
     """
 
     @wraps(f)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+from numpy.typing import NDArray
+import pytest
+
+from auto_uncertainties.exceptions import DowncastWarning
+from auto_uncertainties.util import (
+    has_length,
+    ignore_numpy_downcast_warnings,
+    ignore_runtime_warnings,
+    is_iterable,
+    ndarray_to_scalar,
+    strip_device_array,
+)
+
+
+@pytest.mark.parametrize(
+    "warning, should_raise",
+    [
+        (RuntimeWarning, False),
+    ],
+)
+def test_ignore_runtime_warnings(warning, should_raise):
+    @ignore_runtime_warnings
+    def test_func():
+        warnings.warn("warning!", warning)
+
+    if should_raise:
+        with pytest.warns(warning):
+            test_func()
+    else:
+        test_func()
+
+    # TODO: Improve this (decorator seems to block all warnings?)
+
+
+@pytest.mark.parametrize("warning, should_raise", [(DowncastWarning, False)])
+def test_ignore_numpy_downcast_warnings(warning, should_raise):
+    @ignore_numpy_downcast_warnings
+    def test_func():
+        warnings.warn("warning!", warning)
+
+    if should_raise:
+        with pytest.warns(warning):
+            test_func()
+    else:
+        test_func()
+
+    # TODO: Improve this (decorator seems to block all warnings?)
+
+
+@pytest.mark.parametrize(
+    "obj, iterable",
+    [
+        ([1, 2, 3], True),
+        (2.4, False),
+        ({"a": 1, "b": 2}, True),
+        ("string", True),
+        (np.array([1, 2]), True),
+        (Exception(), False),
+    ],
+)
+def test_is_iterable(obj, iterable):
+    assert is_iterable(obj) is iterable
+
+
+@pytest.mark.parametrize(
+    "obj, length",
+    [
+        ("string", True),
+        (2.4, False),
+        (np.array([1, 2, 3]), True),
+        (Exception(), False),
+    ],
+)
+def test_has_length(obj, length):
+    assert has_length(obj) is length
+
+
+@pytest.mark.parametrize(
+    "val, expected",
+    [
+        (np.array([1]), 1),
+        (np.array(["test"]), "test"),
+    ],
+)
+def test_ndarray_to_scalar(val: NDArray, expected):
+    assert ndarray_to_scalar(val) == expected
+
+
+@pytest.mark.parametrize(
+    "val, expected",
+    [
+        ([1, 2, 3], np.array([1, 2, 3])),
+        (np.array([1, 2]), np.array([1, 2])),
+        (2.5, np.array(2.5)),
+    ],
+)
+def test_strip_device_array(val, expected):
+    assert np.array_equal(strip_device_array(val), expected)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,38 +18,42 @@ from auto_uncertainties.util import (
 
 
 @pytest.mark.parametrize(
-    "warning, should_raise",
+    "warning",
     [
-        (RuntimeWarning, False),
+        RuntimeWarning,
     ],
 )
-def test_ignore_runtime_warnings(warning, should_raise):
+def test_ignore_runtime_warnings(warning):
     @ignore_runtime_warnings
+    def test_func_silent():
+        warnings.warn("warning!", warning)
+
     def test_func():
         warnings.warn("warning!", warning)
 
-    if should_raise:
-        with pytest.warns(warning):
-            test_func()
-    else:
+    warnings.simplefilter("error")  # treat warnings as errors
+
+    with pytest.warns(warning):
         test_func()
 
-    # TODO: Improve this (decorator seems to block all warnings?)
+    test_func_silent()
 
 
-@pytest.mark.parametrize("warning, should_raise", [(DowncastWarning, False)])
-def test_ignore_numpy_downcast_warnings(warning, should_raise):
+@pytest.mark.parametrize("warning", [DowncastWarning])
+def test_ignore_numpy_downcast_warnings(warning):
     @ignore_numpy_downcast_warnings
+    def test_func_silent():
+        warnings.warn("warning!", warning)
+
     def test_func():
         warnings.warn("warning!", warning)
 
-    if should_raise:
-        with pytest.warns(warning):
-            test_func()
-    else:
+    warnings.simplefilter("error")  # treat warnings as errors
+
+    with pytest.warns(warning):
         test_func()
 
-    # TODO: Improve this (decorator seems to block all warnings?)
+    test_func_silent()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds tests for `util`. 

It also adjusts the `draft-pdf` GitHub action to use the new version of `upload-artifact`, as `v1` is now deprecated. 