### PR TITLE
Implement JOSS reviewer suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For array support:
 To install, simply run:
 
 ```
-pip install auto_uncertainties
+pip install auto-uncertainties
 ```
 
 ## Build Documentation
@@ -34,11 +34,25 @@ To build the documentation locally, clone the repository, create a virtual Pytho
 (if desired), and run the following commands within the repository directory:
 
 ```bash
-pip install auto_uncertainties[docs]
+pip install auto-uncertainties[docs]
 sphinx-build docs/source docs/build
 ```
 
 Once built, the docs can be found under the `docs/build` subdirectory.
+
+## CI and Unit Testing
+
+Development of AutoUncertainties relies on a series of unit tests located in the `tests` directory. These
+are automatically run using GitHub actions when commits are pushed to the repository. To run the tests
+manually, first install the package with testing capabilities:
+
+```bash
+pip install auto-uncertainties[CI]
+coverage run -m pytest --cov --cov-report=term --ignore=tests/pandas
+```
+
+At the moment, it makes sense to disable the Pandas tests until certain features are finalized.
+
 
 ## Basic Usage
 

--- a/auto_uncertainties/uncertainty/uncertainty_containers.py
+++ b/auto_uncertainties/uncertainty/uncertainty_containers.py
@@ -48,7 +48,7 @@ UType = TypeVar("UType", np.ndarray, np.floating, float)
 """`TypeVar` specifying the supported underlying types wrapped by `Uncertainty` objects."""
 
 SType = TypeVar("SType", np.floating, float)
-"""`TypeVar` specifying the supported scalar values for `Uncertainty` objects."""
+"""`TypeVar` specifying the supported scalar types for `Uncertainty` objects."""
 
 
 class Uncertainty(Generic[UType]):
@@ -57,6 +57,11 @@ class Uncertainty(Generic[UType]):
 
     Parameters can be numbers, `numpy` arrays, `pint.Quantity` objects,
     other `Uncertainty` objects, or lists / tuples of `Uncertainty` objects.
+
+    `Uncertainty` objects only support float-based data types. If integers or
+    integer arrays are passed as parameters to the `Uncertainty` constructor,
+    they will be cast to `float` (or `numpy.float64` if a `numpy.integer` subclass
+    is detected).
 
     Generally, it is sipmler to let AutoUncertainties determine whether to
     instantiate a `VectorUncertainty` or a `ScalarUncertainty` based on the
@@ -181,9 +186,11 @@ class Uncertainty(Generic[UType]):
         # Zero error
         new_err = 0.0 if err is None else err
 
-        # Convert from int to float
+        # Convert from int to float (maintain NumPy dtypes if detected)
         new_err = float(new_err) if isinstance(new_err, int) else new_err
+        new_err = np.float64(new_err) if isinstance(new_err, np.integer) else new_err
         value = float(value) if isinstance(value, int) else value
+        value = np.float64(value) if isinstance(value, np.integer) else value
 
         nan = False
         if np.isfinite(value):

--- a/auto_uncertainties/uncertainty/uncertainty_containers.py
+++ b/auto_uncertainties/uncertainty/uncertainty_containers.py
@@ -796,8 +796,12 @@ class VectorUncertainty(VectorDisplay, Uncertainty[np.ndarray]):
     @property
     def relative(self):
         rel = np.zeros_like(self._nom)
-        valid = np.isfinite(self._nom) & (self._nom > 0)
-        rel[valid] = self._err[valid] / self._nom[valid]
+        inf = np.isinf(self._nom)
+        nan = self._nom == 0
+        valid = ~inf & ~nan
+        rel[valid] = self._err[valid] / np.abs(self._nom[valid])
+        rel[inf] = np.inf
+        rel[nan] = np.nan
         return rel
 
     @property
@@ -943,7 +947,7 @@ class ScalarUncertainty(ScalarDisplay, Uncertainty[SType]):
     @property
     def relative(self):
         try:
-            return self._err / self._nom
+            return self._err / abs(self._nom)
         except OverflowError:
             return np.inf
         except ZeroDivisionError:

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -13,7 +13,7 @@ Getting Started
 
 .. code:: bash
 
-    pip install auto_uncertainties
+    pip install auto-uncertainties
 
 * The integration with `pandas` (still WIP) can be enabled by installing `pandas`, either separately or via:
 
@@ -21,9 +21,9 @@ Getting Started
 
     pip install auto_uncertainties[pandas]
 
-* The documentation can be built by installing `auto_uncertainties` with the `[docs]` extension:
+* The documentation can be built by installing `auto-uncertainties` with the `[docs]` extension:
 
 .. code:: bash
 
-   pip install auto_uncertainties[docs]
+   pip install auto-uncertainties[docs]
    sphinx-build docs/source docs/build

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -19,7 +19,7 @@ Getting Started
 
 .. code:: bash
 
-    pip install auto_uncertainties[pandas]
+    pip install auto-uncertainties[pandas]
 
 * The documentation can be built by installing `auto-uncertainties` with the `[docs]` extension:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,6 +54,21 @@ Quick Reference
 * :doc:`Exceptions <api/auto_uncertainties/exceptions/index>`
 
 
+CI and Unit Testing
+-------------------
+
+Development of AutoUncertainties relies on a series of unit tests located in the ``tests`` directory. These
+are automatically run using GitHub actions when commits are pushed to the repository. To run the tests
+manually, first install the package with testing capabilities:
+
+.. code-block:: bash
+
+   pip install auto-uncertainties[CI]
+   coverage run -m pytest --cov --cov-report=term --ignore=tests/pandas
+
+
+At the moment, it makes sense to disable the Pandas tests until certain features are finalized.
+
 Inspirations
 ------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,6 +69,71 @@ manually, first install the package with testing capabilities:
 
 At the moment, it makes sense to disable the Pandas tests until certain features are finalized.
 
+
+Current Limitations and Future Work
+-----------------------------------
+
+Dependent Random Variables
+**************************
+
+To simplify operations on `~auto_uncertainties.uncertainty.uncertainty_containers.Uncertainty` objects,
+`AutoUncertainties` assumes all variables are independent and normally distributed. This means that, in
+the case where a user assumes dependence between two or more `Uncertainty` objects, unexpected and
+counter-intuitive behavior may arise during uncertainty propagation. This is a common pitfall when working
+with `Uncertainty` objects, especially since the package will not prevent you from manipulating variables
+in a manner that implies dependence.
+
+- **Subtracting Equivalent Uncertainties**
+
+  Subtracting an `Uncertainty` from itself will not result in a standard deviation of zero:
+
+  .. code-block:: python
+
+     x = Uncertainty(5.0, 0.5)
+     print(x - x)  # 0 +/- 0.707107
+
+- **Mean Error Propagation**
+
+  When multiplying a vector by a scalar `Uncertainty` object, each component of the resulting vector
+  is assumed to be a multivariate normal distribution with no covariance,
+  which may not be the desired behavior. For instance, taking the mean of such a
+  vector will return an `Uncertainty` object with an unexpectedly small standard deviation.
+
+  .. code-block:: python
+
+     u = Uncertainty(5.0, 0.5)
+     arr = np.ones(10) * 10
+     result = np.mean(u * arr)  # 50 +/- 1.58114, rather than 50 +/- 5 as expected
+
+  To obtain the uncertainty corresponding to the case where each element of the array is fully correlated,
+  two workaround techniques can be used:
+
+  1. Separate the central value from the relative error, multiply the vector by the central value, take the mean
+     of the resulting vector, and then multiply by the previously stored relative error.
+
+     .. code-block:: python
+
+        u = Uncertainty(5.0, 0.5)
+        scale_error = Uncertainty(1, u.relative)  # collect relative error
+        scale_value = u.value                     # collect central value
+
+        arr = np.ones(10) * 10
+        result = np.mean(scale_value * arr) * scale_error  # 50 +/- 5
+
+  2. Take the mean of the vector, and then multiply by the `Uncertainty`:
+
+     .. code-block:: python
+
+        u = Uncertainty(5.0, 0.5)
+        arr = np.ones(10) * 10
+        result = u * np.mean(arr)  # 50 +/- 5
+
+These workarounds are nevertheless cumbersome, and cause `AutoUncertainties` to fall somewhat short of the original
+goals of automated error propagation. In principle, this could be addressed by storing a full computational
+graph of the result of chained operations, similar to what is done in `uncertainties`. However, the complexity
+of such a system places it out of scope for `AutoUncertainties` at this time.
+
+
 Inspirations
 ------------
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -115,9 +115,18 @@ seq = Uncertainty.from_sequence([u1, u2])
 print(seq)  # [5.25 +/- 0.75, 1.85 +/- 0.4]
 ```
 
-==============================================
-- TODO: Clarify difference between ScalarUncertainty and VectorUncertainty / how they interact.
-==============================================
+The `Uncertainty` class relies on two subclasses for its full implementation: `ScalarUncertainty` and 
+`VectorUncertainty`. The former is instantiated whenever the programmer uses scalar data types when declaring 
+an `Uncertainty` object, whereas the latter is instantiated whenever `NumPy` arrays are used. In general, 
+`VectorUncertainty` objects support most operations that standard `NumPy` arrays support, whereas 
+`ScalarUncertainty` objects support only scalar operations. `AutoUncertainties` automatically decides which 
+subclass is appropriate, given a user's input. 
+
+It is important to note that `VectorUncertainty` objects are not equivalent to arrays or lists of 
+`ScalarUncertainty` objects. Although indexing into a `VectorUncertainty` will return a `ScalarUncertainty`, 
+programmers should be aware that the `ScalarUncertainty` is constructed spontaneously from an underlying
+`NumPy` array upon request. This allows for vectorized operations on `VectorUncertainty` objects, which
+perform significantly better than executing individual operations on a sequence of `ScalarUncertainty` objects.
 
 To extract errors / central values from arbitrary objects, the accessors `nominal_values` and `std_devs` are provided. 
 These functions return:

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -225,14 +225,6 @@ graph of the result of chained operations, similar to what is done in `uncertain
 of such a system places it out of scope for `AutoUncertainties` at this time.
 
 
-## Typing System
-
-Type hinting is employed throughout `AutoUncertainties` to aid static analysis of the package. At this time,
-however, many typing inconsistencies can be detected by static type enforcement tools like 
-[Mypy](https://mypy-lang.org/) and [Pyright](https://microsoft.github.io/pyright/). Future improvements 
-to `AutoUncertainties` will likely include typing adjustments to the code, in order to avoid subtle bugs.
-
-
 
 # Further Information
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -175,7 +175,7 @@ of this behavior follow.
 
 ### Subtracting Equivalent Uncertainties
 
-Subtracting an `Uncertainty` from itself will not result in a standard devation of zero, as demonstrated
+Subtracting an `Uncertainty` from itself will not result in a standard deviation of zero, as demonstrated
 in the following example: 
 
 ```python

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -25,10 +25,10 @@ date: 7 February 2025
 # Summary
 
 Propagation of uncertainties is of great utility in the experimental sciences.
-While the rules of (linear) uncertainty propagation are simple, managing many 
+While the rules of (linear) uncertainty propagation are straightforward, managing many 
 variables with uncertainty information can quickly become complicated in large 
-scientific software stacks, and require keeping track of many variables and 
-implementing custom error propagation rules for each mathematical operator. 
+scientific software stacks. Often, this requires programmers to keep track of many variables 
+and implement custom error propagation rules for each mathematical operator and function. 
 The Python package `AutoUncertainties`, described here, provides a solution to this problem.
 
 
@@ -39,10 +39,15 @@ a drop-in mechanism to add uncertainty information to Python scalar and `NumPy`
 [@harris2020array] array variables. It implements manual propagation rules for the Python dunder
 math methods, and uses automatic differentiation via `JAX` [@jax2018github] to propagate uncertainties
 for most `NumPy` methods applied to both scalar and `NumPy` array variables. In doing so,
-it eliminates the need for carrying around additional uncertainty variables,
-needing to implement custom propagation rules for any `NumPy` operator with a gradient
-rule implemented by `JAX`, and in most cases requires minimal modification to existing code,
-typically only when uncertainties are attached to central values.
+it eliminates the need for carrying around additional uncertainty variables or
+for implementing custom propagation rules for any `NumPy` operator with a gradient
+rule implemented by `JAX`. Furthermore, in most cases, it requires minimal modification to existing 
+code—typically only when uncertainties are attached to central values.
+
+
+==============================================
+- TODO: Mention why this is necessary (i.e., a particular use case that inspired the package).
+==============================================
 
 
 # Prior Work
@@ -50,11 +55,12 @@ typically only when uncertainties are attached to central values.
 To the author's knowledge, the only existing error propagation library in Python is the `uncertainties` 
 [@lebigot2024] package, which inspired the current work. While extremely useful, the `uncertainties` 
 package relies on hand-implemented rules and functions for uncertainty propagation of array and scalar data. 
-While this is transparent for the intrinsic dunder methods such as `__add__`, it becomes problematic for advanced 
-mathematical operators. For instance, calculating the uncertainty propagation due to the cosine requires the 
-import of separate math libraries
+This is mostly trivial for Python's intrinsic arithmetic and logical operations such as `__add__`, however it becomes 
+problematic for more advanced mathematical operations. For instance, calculating the uncertainty propagation due to 
+the cosine function requires the import of separate math libraries
 
 ```python
+# Using uncertainties v3.2.3
 import numpy as np
 from uncertainties import unumpy, ufloat
 arr = np.array([ufloat(1, 0.1), ufloat(2, 0.002)])
@@ -73,8 +79,9 @@ np.cos(arr)  # raises an exception
 
 # Implementation
 
-Linear uncertainty propagation of a function $f(x) : \mathbb{R}^n \rightarrow \mathbb{R}^m$ can be computed
-via the simple rule $$ \delta f_j (x)^2 = \left ( \dfrac{\partial f_j}{\partial x_i}\left( x \right ) \delta x_i  \right ) ^2. $$
+For a function $f(x) : \mathbb{R}^n \rightarrow \mathbb{R}^m$ of independent and identically distributed (i.i.d.) 
+variables, linear uncertainty propagation can be computed via the simple rule 
+$$ \delta f_j (\mathbf x)^2 = \sum_i^n \left(\dfrac{\partial f_j}{\partial x_i} \delta x_i \right)^2, \quad\quad j \in [1, m].$$
 
 To compute $\dfrac{\partial f_j}{\partial x_i}$ for arbitrary $f$, the implementation in `AutoUncertainties` relies on
 automatic differentiaion provided by `JAX`. Calls to any `NumPy` array function or universal function (ufunc) are 
@@ -107,6 +114,10 @@ print(u1.plus_minus(0.5))  # 5.25 +/- 0.901388
 seq = Uncertainty.from_sequence([u1, u2])
 print(seq)  # [5.25 +/- 0.75, 1.85 +/- 0.4]
 ```
+
+==============================================
+- TODO: Clarify difference between ScalarUncertainty and VectorUncertainty / how they interact.
+==============================================
 
 To extract errors / central values from arbitrary objects, the accessors `nominal_values` and `std_devs` are provided. 
 These functions return:

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -34,7 +34,7 @@ The Python package `AutoUncertainties`, described here, provides a solution to t
 
 # Statement of Need
 
-`AutoUncertainties` is Python package for uncertainty propagation. It provides
+`AutoUncertainties` is a Python package for uncertainty propagation. It provides
 a drop-in mechanism to add uncertainty information to Python scalar and `NumPy`
 [@harris2020array] array variables. It implements manual propagation rules for the Python dunder
 math methods, and uses automatic differentiation via `JAX` [@jax2018github] to propagate uncertainties
@@ -160,7 +160,7 @@ print(type(new_quantity))  # <class 'pint.Quantity'>
 ## Pandas
 
 Support for `pandas` [@pandas2024] via the `ExtensionArray` mechanism is largely functional. Upcoming
-aditions to `AutoUncertainties` will further improve compatibility.
+additions to `AutoUncertainties` will further improve compatibility.
 
 
 

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -901,8 +901,13 @@ class TestVectorUncertainty:
     @staticmethod
     def test_properties():
         v = VectorUncertainty(np.array([1, 2, 3]), np.array([4, 5, 6]))
+        v2 = VectorUncertainty(
+            np.array([1, 0, np.inf]), np.array([4, 5, 6])
+        )  # edge case
 
         assert np.array_equal(v.relative, np.array([4.0, 2.5, 2.0]))
+        assert np.isnan(v2.relative[1])
+        assert np.isinf(v2.relative[2])
         assert np.array_equal(v.rel2, v.relative**2)
         assert v.shape == (3,)
         assert v.nbytes == v._nom.nbytes + v._err.nbytes

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -902,7 +902,7 @@ class TestVectorUncertainty:
     def test_properties():
         v = VectorUncertainty(np.array([1, 2, 3]), np.array([4, 5, 6]))
 
-        assert np.array_equal(v.relative, np.array([4, 2, 2]))
+        assert np.array_equal(v.relative, np.array([4.0, 2.5, 2.0]))
         assert np.array_equal(v.rel2, v.relative**2)
         assert v.shape == (3,)
         assert v.nbytes == v._nom.nbytes + v._err.nbytes


### PR DESCRIPTION
This *[DRAFT]* PR implements some of the changes suggested during the JOSS review process.

In its current (likely to change) state, this PR will:

- Fix a bug where instantiating `Uncertainty` objects with `Sequence` objects (like lists, tuples) would ignore any specified errors.
- Adjust the `relative` property to use absolute value (as it should), and to return `nan` whenever the central value is zero.
- Clarify the uncertainty propagation formula.
- Adjust the documentation to describe how integer data are converted to float data.
- Move the `__array__` method definition from `VectorUncertainty` to `Uncertainty` for consistency.
- Fix some typos in the paper.
- Clarify the relationship between `Uncertainty`, `VectorUncertainty`, and `ScalarUncertainty`.
- Move discussion about certain features of the package out of the paper, and into the docs.
- Slightly improve the typing system using method overloading.