### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+cff-version: "1.2.0"
+authors:
+- family-names: Gopalaswamy
+  given-names: Varchas
+  orcid: "https://orcid.org/0000-0002-8013-9314"
+- family-names: Mentzer
+  given-names: Ethan
+  orcid: "https://orcid.org/0009-0003-8206-5050"
+doi: 10.5281/zenodo.15741742
+message: If you use this software, please cite our article in the
+  Journal of Open Source Software.
+preferred-citation:
+  authors:
+  - family-names: Gopalaswamy
+    given-names: Varchas
+    orcid: "https://orcid.org/0000-0002-8013-9314"
+  - family-names: Mentzer
+    given-names: Ethan
+    orcid: "https://orcid.org/0009-0003-8206-5050"
+  date-published: 2025-07-03
+  doi: 10.21105/joss.08037
+  issn: 2475-9066
+  issue: 111
+  journal: Journal of Open Source Software
+  publisher:
+    name: Open Journals
+  start: 8037
+  title: "AutoUncertainties: A Python Package for Uncertainty
+    Propagation"
+  type: article
+  url: "https://joss.theoj.org/papers/10.21105/joss.08037"
+  volume: 10
+title: "AutoUncertainties: A Python Package for Uncertainty Propagation"


### PR DESCRIPTION
Per https://github.com/openjournals/joss-reviews/issues/8037#issuecomment-3032455865, this PR adds a `CITATION.cff` file.

This can be merged into `main`, and `main` can be subsequently merged into `stable` without needing a new release. 